### PR TITLE
Fix: Change of ff_annotation_route version to previous compatibility

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  ff_annotation_route: any
+  ff_annotation_route: 4.0.0
 
 flutter:
 


### PR DESCRIPTION
The current version (>5.0.0) of ff_annotation_route isn't compatible with the code of this example, I think it should be set to a version actually compatible to make easier to run this example for new users or people wanting to run it.